### PR TITLE
Enable forced merging in workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -42,3 +42,18 @@ jobs:
           delete-branch: true
           merge: true
           merge-method: squash
+
+      - name: Force merge pull request
+        if: steps.cpr.outputs.pull-request-number != ''
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER),
+              merge_method: 'squash'
+            })
+        env:
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to force merge newly created PRs using `github-script`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686db88c4814832daafc91444c8bffa2