### PR TITLE
Fix controls toolbar toggle

### DIFF
--- a/template.md
+++ b/template.md
@@ -6,8 +6,10 @@ title: World News
 <div markdown="0">
 
 <div id="controls">
-    <!-- a clickable fas gear icon which opens/collapses a div containing controls for the feed -->
-    <a class="fas fa-gear" data-toggle="collapse" href="#controls-collapse" role="button" aria-expanded="false" aria-controls="controls-collapse"></a>
+    <!-- a clickable gear button that opens/collapses a div containing controls for the feed -->
+    <button class="btn btn-outline-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#controls-collapse" aria-expanded="false" aria-controls="controls-collapse">
+        <i class="fas fa-gear"></i>
+    </button>
     <div class="collapse" id="controls-collapse">
         <!--- radio buttons for Show stories from 1h, 24h, 1d -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">


### PR DESCRIPTION
## Summary
- make the gear icon a button
- use Bootstrap 5 attributes so the controls collapse works

## Testing
- `python -m py_compile $(find . -name '*.py')` *(fails: py_compile.py requires filenames)*

------
https://chatgpt.com/codex/tasks/task_e_688151fc0910832da006ad5c9d92595d