### PR TITLE
Update radio button groups

### DIFF
--- a/archive/2025-07-23-21-00-00.md
+++ b/archive/2025-07-23-21-00-00.md
@@ -14,23 +14,23 @@ title: World News
         <!--- radio buttons for Show stories from 1h, 24h, 1d -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
             Show stories from:
+            <label class="btn btn-secondary">
+                <input type="radio" name="period" id="option1" autocomplete="off"> 1h
+            </label>
             <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option1" autocomplete="off" checked> 1h
+                <input type="radio" name="period" id="option2" autocomplete="off" checked> 24h
             </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option2" autocomplete="off"> 24h
-            </label>
-            <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option3" autocomplete="off"> 1d
+                <input type="radio" name="period" id="option3" autocomplete="off"> 1d
             </label>
         </div>
         <!--- radio buttons for Show All, Show Top -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
-            <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option4" autocomplete="off" checked> Show All
-            </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option5" autocomplete="off"> Show Top
+                <input type="radio" name="view" id="option4" autocomplete="off"> Show All
+            </label>
+            <label class="btn btn-secondary active">
+                <input type="radio" name="view" id="option5" autocomplete="off" checked> Show Top
             </label>
         </div>
     </div>

--- a/index.md
+++ b/index.md
@@ -14,23 +14,23 @@ title: World News
         <!--- radio buttons for Show stories from 1h, 24h, 1d -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
             Show stories from:
+            <label class="btn btn-secondary">
+                <input type="radio" name="period" id="option1" autocomplete="off"> 1h
+            </label>
             <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option1" autocomplete="off" checked> 1h
+                <input type="radio" name="period" id="option2" autocomplete="off" checked> 24h
             </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option2" autocomplete="off"> 24h
-            </label>
-            <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option3" autocomplete="off"> 1d
+                <input type="radio" name="period" id="option3" autocomplete="off"> 1d
             </label>
         </div>
         <!--- radio buttons for Show All, Show Top -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
-            <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option4" autocomplete="off" checked> Show All
-            </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option5" autocomplete="off"> Show Top
+                <input type="radio" name="view" id="option4" autocomplete="off"> Show All
+            </label>
+            <label class="btn btn-secondary active">
+                <input type="radio" name="view" id="option5" autocomplete="off" checked> Show Top
             </label>
         </div>
     </div>

--- a/template.html
+++ b/template.html
@@ -11,23 +11,23 @@ title: World News
         <!--- radio buttons for Show stories from 1h, 24h, 1d -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
             Show stories from:
+            <label class="btn btn-secondary">
+                <input type="radio" name="period" id="option1" autocomplete="off"> 1h
+            </label>
             <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option1" autocomplete="off" checked> 1h
+                <input type="radio" name="period" id="option2" autocomplete="off" checked> 24h
             </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option2" autocomplete="off"> 24h
-            </label>
-            <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option3" autocomplete="off"> 1d
+                <input type="radio" name="period" id="option3" autocomplete="off"> 1d
             </label>
         </div>
         <!--- radio buttons for Show All, Show Top -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
-            <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option4" autocomplete="off" checked> Show All
-            </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option5" autocomplete="off"> Show Top
+                <input type="radio" name="view" id="option4" autocomplete="off"> Show All
+            </label>
+            <label class="btn btn-secondary active">
+                <input type="radio" name="view" id="option5" autocomplete="off" checked> Show Top
             </label>
         </div>
     </div>

--- a/template.md
+++ b/template.md
@@ -14,23 +14,23 @@ title: World News
         <!--- radio buttons for Show stories from 1h, 24h, 1d -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
             Show stories from:
+            <label class="btn btn-secondary">
+                <input type="radio" name="period" id="option1" autocomplete="off"> 1h
+            </label>
             <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option1" autocomplete="off" checked> 1h
+                <input type="radio" name="period" id="option2" autocomplete="off" checked> 24h
             </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option2" autocomplete="off"> 24h
-            </label>
-            <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option3" autocomplete="off"> 1d
+                <input type="radio" name="period" id="option3" autocomplete="off"> 1d
             </label>
         </div>
         <!--- radio buttons for Show All, Show Top -->
         <div class="btn-group btn-group-toggle" data-toggle="buttons">
-            <label class="btn btn-secondary active">
-                <input type="radio" name="options" id="option4" autocomplete="off" checked> Show All
-            </label>
             <label class="btn btn-secondary">
-                <input type="radio" name="options" id="option5" autocomplete="off"> Show Top
+                <input type="radio" name="view" id="option4" autocomplete="off"> Show All
+            </label>
+            <label class="btn btn-secondary active">
+                <input type="radio" name="view" id="option5" autocomplete="off" checked> Show Top
             </label>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- separate the radio button sets so selecting an item in one row doesn't affect the other
- default the period selector to 24h
- default the story selector to Top Stories

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688159ff1190832d8ef6461266232bdd