### PR TITLE
Update run notebook with all lists

### DIFF
--- a/run.ipynb
+++ b/run.ipynb
@@ -132,6 +132,28 @@
     "if __name__ == '__main__':\n",
     "    main()\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_sorted(path):\n",
+    "    \"\"\"Return items from path sorted by pubdate descending.\"\"\"\n",
+    "    text = Path(path).read_text(encoding='utf-8')\n",
+    "    items = json.loads(text)\n",
+    "    items = sorted(\n",
+    "        items,\n",
+    "        key=lambda x: dt.datetime.strptime(x['pubdate'], '%Y-%m-%d-%H-%M-%S %z'),\n",
+    "        reverse=True\n",
+    "    )\n",
+    "    return convert_data(items)\n",
+    "\n",
+    "all1h_html = build_list(load_sorted('1h.json'))\n",
+    "all24h_html = build_list(load_sorted('24h.json'))\n",
+    "all7d_html = build_list(load_sorted('7d.json'))\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- extend `run.ipynb` with an extra cell that reads JSON data for each time period
- sort the loaded items by `pubdate` and build HTML for the corresponding *all* lists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68815fb44308832da9040f091f6472cf